### PR TITLE
Add --img-invert to invert pixels

### DIFF
--- a/pricetag_printer/img.py
+++ b/pricetag_printer/img.py
@@ -30,7 +30,8 @@ def read_img(
         print_width,
         logger,
         img_binarization_algo,
-        show_preview):
+        show_preview,
+        invert):
     im = cv2.imread(filename, cv2.IMREAD_GRAYSCALE)
     height = im.shape[0]
     width = im.shape[1]
@@ -42,14 +43,18 @@ def read_img(
         logger.info(f'⏳ Applying Floyd-Steinberg dithering to image...')
         floyd_steinberg_dither(resized)
         logger.info(f'✅ Done.')
-        resized = resized > 127
+        threshold = 127
     elif img_binarization_algo == 'mean-threshold':
-        resized = resized > resized.mean()
+        threshold = resized.mean()
     else:
         logger.error(
             f'🛑 Unknown image binarization algorithm: {img_binarization_algo}')
         raise RuntimeError(
             f'unknown image binarization algorithm: {img_binarization_algo}')
+    if invert:
+        resized = resized <= threshold
+    else:
+        resized = resized > threshold
 
     if show_preview:
         # Convert from our boolean representation to float.

--- a/print.py
+++ b/print.py
@@ -25,6 +25,8 @@ def parse_args():
                       help='If set, displays the final image and asks the user for confirmation before printing.')
     args.add_argument('--devicename', type=str, default='GT01',
                       help='Specify the Bluetooth device name to search for. Default value is GT01.')
+    args.add_argument('--img-invert', action='store_true',
+                      help='Invert resulting pixels.')
     return args.parse_args()
 
 
@@ -49,7 +51,7 @@ def main():
         return
 
     bin_img = read_img(args.filename, EPD_HEIGHT,
-                       logger, args.img_binarization_algo, args.show_preview)
+                       logger, args.img_binarization_algo, args.show_preview, args.img_invert)
     if bin_img is None:
         logger.info(f'🛑 No image generated. Exiting.')
         return


### PR DESCRIPTION
Trivial PR to add "--img-invert" option to invert final pixels.

I needed such option as, for some reason, my Hanshow tag (firmware ?) version actually invert displayed pixels.
